### PR TITLE
Feature/add helper funcs

### DIFF
--- a/src/validr/schema.py
+++ b/src/validr/schema.py
@@ -269,10 +269,11 @@ class Schema:
 
 class Compiler:
 
-    def __init__(self, validators=None, is_dump=False):
+    def __init__(self, validators=None, helpers=None, is_dump=False):
         self.validators = builtin_validators.copy()
         if validators:
             self.validators.update(validators)
+        self.helpers = helpers
         self.is_dump = is_dump
 
     def compile(self, schema):


### PR DESCRIPTION
You may specify general purpose helper functions for the compiler like this:
```python
compiled = Compiler(
                        validators={
                            'enum': enum_validator,
                            'netaddr': netaddr_validator
                        },
                        helpers={
                            'rule_unique': rule_key_func
                        }
                    ).compile(plain_rule_list_in)
```
and then use them in list checker
```python
from validr import T, modelclass, asdict, validator, Compiler

plain_rule_schema_in = T.dict(
    enabled=T.bool.optional.default,
    ttl=T.int.optional,
    settings=T.dict(
        addr=T.netaddr
    )
)

plain_rule_list_in = T.dict(
    name=T.str,
    enabled=T.bool,
    description=T.str.optional.default(''),
    category=T.enum(
        ','.join([category.name for category in RuleListCategoriesEnum])
    ),
    rules=T.list(
        plain_rule_schema_in,
    ).maxlen(100000).unique.optional.unique_key_helper('rule_unique')
)

```

helper function value must be unique for each list entity

e.g:
```python
def rule_key_func(value):
    return json.dumps(value)
```
