### PR TITLE
fix list unique check slow. #17

### DIFF
--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -35,6 +35,14 @@ from . import case, compiler
             [{'key': 1}, {'key': 1}],
         ]
     },
+    T.list(T.dict(key=T.dict(key=T.int))).unique: {
+        'valid': [
+            [{'key': {'key': 1}}, {'key': {'key': 2}}],
+        ],
+        'invalid': [
+            [{'key': {'key': 1}}, {'key': {'key': 1}}]
+        ]
+    },
     T.list(T.list(T.int)).unique: {
         'valid': [
             [
@@ -46,6 +54,20 @@ from . import case, compiler
             [
                 [1, 2],
                 [1, 2],
+            ],
+        ]
+    },
+    T.list(T.list(T.dict(key=T.int))).unique: {
+        'valid': [
+            [
+                [{'key': 1}, {'key': 1}],
+                [{'key': 2}, {'key': 2}],
+            ],
+        ],
+        'invalid': [
+            [
+                [{'key': 1}, {'key': 2}],
+                [{'key': 1}, {'key': 2}],
             ],
         ]
     },
@@ -68,10 +90,8 @@ def test_list():
     T.list.unique,
     T.list(T.dict).unique,
     T.list(T.list).unique,
-    T.list(T.dict(key=T.dict(key=T.int))).unique,
-    T.list(T.list(T.dict(key=T.int))).unique,
 ])
 def test_unable_check_unique(schema):
     with pytest.raises(SchemaError) as exinfo:
         compiler.compile(schema)
-    assert 'Unable to check unique' in exinfo.value.message
+    assert 'unable to check unique' in exinfo.value.message


### PR DESCRIPTION
The unique check is O(1) operation for each item, the key function is based on inner schema. 
Only list of types below are available:

1. scalar type, eg: bool, int, float, str
2. list of scalar type
3. dict of scalar type value

other types will cause SchemaError.