### PR TITLE
Feature: union schema and validator

### DIFF
--- a/benchmark/case_validr.py
+++ b/benchmark/case_validr.py
@@ -4,7 +4,10 @@ from validr import T, Compiler, modelclass, asdict, builtin_validators
 @modelclass
 class Model:
     user = T.dict(userid=T.int.min(0).max(9).desc("UserID"))
-    tags = T.list(T.int.min(0))
+    tags = T.union([
+        T.int.min(0),
+        T.list(T.int.min(0)),
+    ])
     style = T.dict(
         width=T.int.desc("width"),
         height=T.int.desc("height"),

--- a/tasks.py
+++ b/tasks.py
@@ -14,18 +14,21 @@ def clean(ctx):
 
 
 @task(pre=[clean])
-def test(ctx, profile=False):
+def test(ctx, benchmark=False, profile=False, k=None):
+    pytest_k = ' -k {}'.format(k) if k is not None else ''
     os.environ['VALIDR_SETUP_MODE'] = 'dist_dbg'
     ctx.run('pip install --no-deps -e .')
     # cython speedup mode
-    ctx.run('pytest --cov=validr --cov-report=term-missing')
-    ctx.run('python benchmark/benchmark.py benchmark --validr')
+    ctx.run('pytest --cov=validr --cov-report=term-missing' + pytest_k)
+    if benchmark:
+        ctx.run('python benchmark/benchmark.py benchmark --validr')
     if profile:
         ctx.run('python benchmark/benchmark.py profile')
     # pure python mode
     ctx.run('rm -rf src/validr/*.so')
-    ctx.run('pytest --cov=validr --cov-report=term-missing --cov-config=.coveragerc_py')
-    ctx.run('python benchmark/benchmark.py benchmark --validr')
+    ctx.run('pytest --cov=validr --cov-report=term-missing --cov-config=.coveragerc_py' + pytest_k)
+    if benchmark:
+        ctx.run('python benchmark/benchmark.py benchmark --validr')
     if profile:
         ctx.run('python benchmark/benchmark.py profile')
 

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,4 +1,4 @@
-from validr import Invalid, mark_index, mark_key
+from validr import Invalid, SchemaError, T, mark_index, mark_key
 
 from .helper import expect_position
 
@@ -48,6 +48,10 @@ def test_exception_str():
 
     ex = Invalid()
     assert str(ex) == 'invalid'
+
+    assert str(Invalid('invalid', value=123)) == 'invalid, value=123'
+
+    assert str(SchemaError('invalid', value=T.str.__schema__)) == 'invalid, schema=str'
 
     ex = Invalid(value='x' * 1000)
     assert len(str(ex)) < 100

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -1,5 +1,5 @@
 import pytest
-from validr import T, SchemaError
+from validr import T, SchemaError, Invalid
 from . import case, compiler
 
 
@@ -18,44 +18,19 @@ from . import case, compiler
         (None, ''),
         [123],
     ],
-    T.union([T.str, T.list(T.str)]).default('ddd'): [
-        ('xxx', 'xxx'),
+    T.union([T.list(T.str)]).optional: [
         (['xxx', 'yyy'], ['xxx', 'yyy']),
-        ([], []),
-        ('', 'ddd'),
-        (None, 'ddd'),
-        [123],
+        (None, None),
+        ['xxx', '', 123],
     ],
     T.union([
         T.str,
         T.list(T.str),
-        T.dict(key1=T.str, key2=T.str, key4=T.str),
-        T.dict(key1=T.str, key2=T.str, key3=T.str),
-        T.dict(key1=T.str, key2=T.str),
-        T.dict(key1=T.str),
-        T.dict,
+        T.dict(key=T.str),
     ]): [
         ('xxx', 'xxx'),
         (['xxx', 'yyy'], ['xxx', 'yyy']),
-        ({}, {}),
-        ({'xxx': 'vvv'}, {'xxx': 'vvv'}),
-        ({'key1': 'v1', 'xxx': 'vvv'}, {'key1': 'v1'}),
-        (
-            {'key1': 'v1', 'key2': 'v2', 'xxx': 'vvv'},
-            {'key1': 'v1', 'key2': 'v2'}
-        ),
-        (
-            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3', 'xxx': 'vvv'},
-            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3'}
-        ),
-        (
-            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4', 'xxx': 'vvv'},
-            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4'}
-        ),
-        (
-            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3', 'key4': 'v4', 'xxx': 'vvv'},
-            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4'}
-        ),
+        ({'key': 'vvv'}, {'key': 'vvv'}),
     ]
 })
 def test_union_list():
@@ -75,6 +50,15 @@ def test_union_list():
             'xxx',
             None,
         ]
+    ],
+    T.union(
+        type1=T.dict(key=T.str),
+    ).by('type').optional: [
+        ({'type': 'type1', 'key': 'xxx'}, {'type': 'type1', 'key': 'xxx'}),
+        (None, None),
+        [
+            {'type': 'xxx', 'key': 'xxx'},
+        ]
     ]
 })
 def test_union_dict():
@@ -82,33 +66,101 @@ def test_union_dict():
 
 
 def test_compile_union():
-    with pytest.raises(SchemaError):
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union)
-    with pytest.raises(SchemaError):
+    assert 'union schemas not provided' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
+        compiler.compile(T.union([T.str]).default('xxx'))
+    assert 'default' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union([T.str]).by('type'))
-    with pytest.raises(SchemaError):
+    assert 'by' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union(t1=T.dict(k1=T.str), t2=T.dict(k2=T.str)))
-    with pytest.raises(SchemaError):
+    assert 'by' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union(t1=T.dict(k1=T.str)).by(123))
+    assert 'by' in exinfo.value.message
 
 
 def test_compile_union_list():
-    with pytest.raises(SchemaError):
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union([T.union([T.str])]))
-    with pytest.raises(SchemaError):
+    assert 'ambiguous' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union([T.str.optional]))
-    with pytest.raises(SchemaError):
+    assert 'optional' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
+        compiler.compile(T.union([T.str.default('xxx')]))
+    assert 'default' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union([T.int, T.str]))
-    with pytest.raises(SchemaError):
+    assert 'ambiguous' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union([T.list(T.int), T.list(T.int)]))
-    with pytest.raises(SchemaError):
-        compiler.compile(T.union([T.dict(k=T.str), T.dict(k=T.int)]))
-    with pytest.raises(SchemaError):
-        compiler.compile(T.union([T.dict(k=T.str), T.dict(k=T.str, k2=T.int.optional)]))
+    assert 'ambiguous' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
+        compiler.compile(T.union([T.dict(k1=T.str), T.dict(k2=T.int)]))
+    assert 'ambiguous' in exinfo.value.message
 
 
 def test_compile_union_dict():
-    with pytest.raises(SchemaError):
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union(k1=T.str).by('type'))
-    with pytest.raises(SchemaError):
+    assert 'dict' in exinfo.value.message
+
+    with pytest.raises(SchemaError) as exinfo:
         compiler.compile(T.union(k1=T.dict.optional).by('type'))
+    assert 'optional' in exinfo.value.message
+
+
+def test_union_list_error_position():
+    f = compiler.compile(T.list(T.union([
+        T.int,
+        T.list(T.int),
+        T.dict(k=T.int),
+    ])))
+
+    with pytest.raises(Invalid) as exinfo:
+        f([123, 'xxx'])
+    assert exinfo.value.position == '[1]'
+
+    with pytest.raises(Invalid) as exinfo:
+        f([123, [456, 'xxx']])
+    assert exinfo.value.position == '[1][1]'
+
+    with pytest.raises(Invalid) as exinfo:
+        f([123, {'k': 'xxx'}])
+    assert exinfo.value.position == '[1].k'
+
+
+def test_union_dict_error_position():
+    f = compiler.compile(T.union(
+        t1=T.dict(k1=T.int),
+        t2=T.dict(k2=T.list(T.int)),
+    ).by('type'))
+
+    with pytest.raises(Invalid) as exinfo:
+        f({'k1': 123})
+    assert exinfo.value.position == 'type'
+
+    with pytest.raises(Invalid) as exinfo:
+        f({'k1': 'xxx', 'type': 'txxx'})
+    assert exinfo.value.position == 'type'
+
+    with pytest.raises(Invalid) as exinfo:
+        f({'k1': 'xxx', 'type': 't1'})
+    assert exinfo.value.position == 'k1'
+
+    with pytest.raises(Invalid) as exinfo:
+        f({'k2': ['xxx'], 'type': 't2'})
+    assert exinfo.value.position == 'k2[0]'

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -1,0 +1,114 @@
+import pytest
+from validr import T, SchemaError
+from . import case, compiler
+
+
+@case({
+    T.union([T.str, T.list(T.str)]): [
+        ('xxx', 'xxx'),
+        (['xxx', 'yyy'], ['xxx', 'yyy']),
+        ([], []),
+        [None, '', 123],
+    ],
+    T.union([T.str, T.list(T.str)]).optional: [
+        ('xxx', 'xxx'),
+        (['xxx', 'yyy'], ['xxx', 'yyy']),
+        ([], []),
+        ('', ''),
+        (None, ''),
+        [123],
+    ],
+    T.union([T.str, T.list(T.str)]).default('ddd'): [
+        ('xxx', 'xxx'),
+        (['xxx', 'yyy'], ['xxx', 'yyy']),
+        ([], []),
+        ('', 'ddd'),
+        (None, 'ddd'),
+        [123],
+    ],
+    T.union([
+        T.str,
+        T.list(T.str),
+        T.dict(key1=T.str, key2=T.str, key4=T.str),
+        T.dict(key1=T.str, key2=T.str, key3=T.str),
+        T.dict(key1=T.str, key2=T.str),
+        T.dict(key1=T.str),
+        T.dict,
+    ]): [
+        ('xxx', 'xxx'),
+        (['xxx', 'yyy'], ['xxx', 'yyy']),
+        ({}, {}),
+        ({'xxx': 'vvv'}, {'xxx': 'vvv'}),
+        ({'key1': 'v1', 'xxx': 'vvv'}, {'key1': 'v1'}),
+        (
+            {'key1': 'v1', 'key2': 'v2', 'xxx': 'vvv'},
+            {'key1': 'v1', 'key2': 'v2'}
+        ),
+        (
+            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3', 'xxx': 'vvv'},
+            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3'}
+        ),
+        (
+            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4', 'xxx': 'vvv'},
+            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4'}
+        ),
+        (
+            {'key1': 'v1', 'key2': 'v2', 'key3': 'v3', 'key4': 'v4', 'xxx': 'vvv'},
+            {'key1': 'v1', 'key2': 'v2', 'key4': 'v4'}
+        ),
+    ]
+})
+def test_union_list():
+    pass
+
+
+@case({
+    T.union(
+        type1=T.dict(key=T.str),
+        type2=T.dict(key=T.list(T.int)),
+    ).by('type'): [
+        ({'type': 'type1', 'key': 'xxx'}, {'type': 'type1', 'key': 'xxx'}),
+        ({'type': 'type2', 'key': [1, 2, 3]}, {'type': 'type2', 'key': [1, 2, 3]}),
+        [
+            {'type': 'xxx', 'key': 'xxx'},
+            {'key': 'xxx'},
+            'xxx',
+            None,
+        ]
+    ]
+})
+def test_union_dict():
+    pass
+
+
+def test_compile_union():
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union)
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.str]).by('type'))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union(t1=T.dict(k1=T.str), t2=T.dict(k2=T.str)))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union(t1=T.dict(k1=T.str)).by(123))
+
+
+def test_compile_union_list():
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.union([T.str])]))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.str.optional]))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.int, T.str]))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.list(T.int), T.list(T.int)]))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.dict(k=T.str), T.dict(k=T.int)]))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union([T.dict(k=T.str), T.dict(k=T.str, k2=T.int.optional)]))
+
+
+def test_compile_union_dict():
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union(k1=T.str).by('type'))
+    with pytest.raises(SchemaError):
+        compiler.compile(T.union(k1=T.dict.optional).by('type'))


### PR DESCRIPTION
#### 1. union list (distinguish schemas by value type)

```python
schema = T.union([...schema])
example = T.union([T.str, T.list(T.str), T.dict(key=T.str)])
```

Limit: at most one dict schema, one list schema and one scalar(int, str, ...) schema in schemas.

#### 2. union dict (distinguish schemas by specified field)

```python
schema = T.union(xxx=T.dict, ...).by(field)
example = T.union(type1=T.dict, type2=T.dict).by('type')
```


Related https://github.com/guyskk/validr/issues/34