### PR TITLE
Feature: Dynamic dict keys and str validator update

### DIFF
--- a/src/validr/_validator_c.pyx
+++ b/src/validr/_validator_c.pyx
@@ -577,7 +577,7 @@ def str_validator(compiler, int minlen=0, int maxlen=1024 * 1024,
 
     def validate(value):
         if not isinstance(value, str):
-            if accept_object:
+            if accept_object or isinstance(value, int):
                 value = str(value)
             else:
                 raise Invalid('invalid string')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -93,3 +93,17 @@ def test_union_dict():
     assert T(schema.__schema__.to_primitive()) == schema
     with pytest.raises(SchemaError):
         T.union(type1=T.dict, type2=dict)
+
+
+def test_dynamic_dict():
+    schema = T.dict(labels=T.list(T.str)).key(
+        T.str.minlen(2)
+    ).value(
+        T.list(T.int)
+    ).optional
+    assert T(json.loads(str(schema))) == schema
+    assert T(schema.__schema__.to_primitive()) == schema
+    with pytest.raises(SchemaError):
+        T.dict.key('abc')
+    with pytest.raises(SchemaError):
+        T.dict.value('abc')

--- a/tests/validators/test_str.py
+++ b/tests/validators/test_str.py
@@ -7,7 +7,8 @@ from . import case
         ('中文', '中文'),
         ('123', '123'),
         (str('abc'), 'abc'),
-        [None, '', b'', 123, b'abc', '中文'.encode('utf-8')]
+        (123, '123'),
+        [None, '', b'', b'abc', '中文'.encode('utf-8')]
     ],
     T.str.default('中文'): [
         (None, '中文'),

--- a/tests/validators/test_str.py
+++ b/tests/validators/test_str.py
@@ -26,6 +26,15 @@ from . import case
         ('中文', '中文'),
         ("&><'\"", '&amp;&gt;&lt;&#39;&#34;')
     ],
+    T.str.strip: [
+        (' aaa ', 'aaa'),
+        (' 中文 ', '中文'),
+        [' ', '  ', None]
+    ],
+    T.str.match("[a-z]+"): [
+        ('aaz', 'aaz'),
+        [None, '', 'aA', 'zZ', 'a0', 'a-'],
+    ]
 })
 def test_str():
     pass

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -4,33 +4,31 @@ from . import case, compiler
 
 
 @case({
-    T.union([T.str, T.list(T.str)]): [
-        ('xxx', 'xxx'),
-        (['xxx', 'yyy'], ['xxx', 'yyy']),
+    T.union([T.int, T.list(T.int)]): [
+        (111, 111),
+        ([111, 222], [111, 222]),
         ([], []),
-        [None, '', 123],
+        [None, '', 'xxx'],
     ],
     T.union([T.str, T.list(T.str)]).optional: [
-        ('xxx', 'xxx'),
-        (['xxx', 'yyy'], ['xxx', 'yyy']),
         ([], []),
-        ('', ''),
         (None, ''),
-        [123],
+        ('', ''),
+        [object],
     ],
-    T.union([T.list(T.str)]).optional: [
-        (['xxx', 'yyy'], ['xxx', 'yyy']),
+    T.union([T.list(T.int)]).optional: [
+        ([111, 222], [111, 222]),
         (None, None),
-        ['xxx', '', 123],
+        ['xxx', '', ['yyy']],
     ],
     T.union([
-        T.str,
-        T.list(T.str),
-        T.dict(key=T.str),
+        T.int,
+        T.list(T.int),
+        T.dict(key=T.int),
     ]): [
-        ('xxx', 'xxx'),
-        (['xxx', 'yyy'], ['xxx', 'yyy']),
-        ({'key': 'vvv'}, {'key': 'vvv'}),
+        (111, 111),
+        ([111, 222], [111, 222]),
+        ({'key': 333}, {'key': 333}),
     ]
 })
 def test_union_list():

--- a/validr_uncython.py
+++ b/validr_uncython.py
@@ -19,7 +19,7 @@ def pyx_to_py(text: str, debug=False):
                     line = line.replace(cdef_t, '')
                 else:
                     line = re.sub(r'(\s*)(\S.*)', r'\1# \2', line)
-        if re.match(r'\s*\w*def\s\w+\(.*(,|\):)', line) or re.match(r'\s+.*=.*\):', line):
+        if re.match(r'\s*\w*def\s\w+\(.*(,|\):)', line) or re.match(r'\s+.*=.*(\):$|,$)', line):
             line = re.sub(r'(bint|str|int|float|dict|list)\s(\w+)', r'\2', line)
         if debug and origin != line:
             print('{:>3d}- '.format(i) + origin, end='')


### PR DESCRIPTION
Schema in Python: 
```python
schema = T.dict.key(...).value(...)
example1 = T.dict.key(T.str.match("[a-z]+")).value(T.int)
example2 = T.dict(xxx=T.str).key(T.str.match("[a-z]+")).value(T.int)
```

Schema in JSON:

```json
{
    "$self": "dict",
    "$self_key": "...",
    "$self_value": "..."
}
```

Note: only accept dict value, not support other objects. value's additional keys which not match key schema will cause Invalid.

Related: #35 

#### Other Changes:

- str validator accept int value
- str validator add `match` parameter
